### PR TITLE
several application Versions error and memory calculation error for saveLocation=nowhere

### DIFF
--- a/Kaenx.Creator/Classes/AutoHelper.cs
+++ b/Kaenx.Creator/Classes/AutoHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -271,7 +271,7 @@ namespace Kaenx.Creator.Classes
 
         private static void MemCalcStatics(IVersionBase vbase, Memory mem, int memId)
         {
-            List<Parameter> paras = vbase.Parameters.Where(p => p.MemoryId == memId && p.IsInUnion == false).ToList();
+            List<Parameter> paras = vbase.Parameters.Where(p => p.MemoryId == memId && p.IsInUnion == false && p.SavePath != SavePaths.Nowhere).ToList();
 
             foreach(Parameter para in paras.Where(p => p.Offset != -1))
             {
@@ -287,7 +287,7 @@ namespace Kaenx.Creator.Classes
                 mem.SetBytesUsed(para);
             }
 
-            foreach (Union union in vbase.Unions.Where(u => u.MemoryId == mem.UId && u.Offset != -1))
+            foreach (Union union in vbase.Unions.Where(u => u.MemoryId == mem.UId && u.Offset != -1 && u.SavePath != SavePaths.Nowhere))
             {
                 if(union.Offset >= mem.GetCount())
                 {
@@ -304,7 +304,7 @@ namespace Kaenx.Creator.Classes
 
         private static void MemCalcAuto(IVersionBase vbase, Memory mem, int memId)
         {
-            List<Parameter> paras = vbase.Parameters.Where(p => p.MemoryId == memId && p.IsInUnion == false).ToList();
+            List<Parameter> paras = vbase.Parameters.Where(p => p.MemoryId == memId && p.IsInUnion == false && p.SavePath != SavePaths.Nowhere).ToList();
             IEnumerable<Parameter> list1;
             if(mem.IsAutoOrder) list1 = paras.ToList();
             else list1 = paras.Where(p => p.Offset == -1);
@@ -317,7 +317,7 @@ namespace Kaenx.Creator.Classes
             }
 
             IEnumerable<Union> list2;
-            if(mem.IsAutoOrder) list2 = vbase.Unions.Where(u => u.MemoryId == memId);
+            if(mem.IsAutoOrder) list2 = vbase.Unions.Where(u => u.MemoryId == memId && u.SavePath != SavePaths.Nowhere);
             else list2 = vbase.Unions.Where(u => u.MemoryId == memId && u.Offset == -1);
             foreach (Union union in list2)
             {

--- a/Kaenx.Creator/Classes/CheckHelper.cs
+++ b/Kaenx.Creator/Classes/CheckHelper.cs
@@ -663,17 +663,20 @@ namespace Kaenx.Creator.Classes {
             {
                 if(!citem.IsSection)
                 {
-                    Application app = general.Applications.Single(a => a.Versions.Any(v => v.Number == vers.Number));
-                    if(devices != null && citem.Hardware.Apps.Contains(app))
+                    List<Application> appList = general.Applications.ToList().FindAll(a => a.Versions.Any(v => v.Number == vers.Number));
+                    foreach (Application app in appList)
                     {
-                        foreach(Device dev in citem.Hardware.Devices.Where(d => devices.Contains(d)))
+                        if (devices != null && citem.Hardware.Apps.Contains(app))
                         {
-                            foreach(Language lang in vers.Languages)
+                            foreach (Device dev in citem.Hardware.Devices.Where(d => devices.Contains(d)))
                             {
-                                if(!dev.Text.Any(l => l.Language.CultureCode == lang.CultureCode || string.IsNullOrEmpty(l.Text)))
-                                    actions.Add(new PublishAction() { Text = $"Geräte: Text enthält nicht alle Sprachen der Applikation.", State = PublishState.Fail });
-                                if(!dev.Description.Any(l => l.Language.CultureCode == lang.CultureCode || string.IsNullOrEmpty(l.Text)))
-                                    actions.Add(new PublishAction() { Text = $"Geräte: Beschreibung enthält nicht alle Sprachen der Applikation.", State = PublishState.Fail });
+                                foreach (Language lang in vers.Languages)
+                                {
+                                    if (!dev.Text.Any(l => l.Language.CultureCode == lang.CultureCode || string.IsNullOrEmpty(l.Text)))
+                                        actions.Add(new PublishAction() { Text = $"Geräte: Text enthält nicht alle Sprachen der Applikation.", State = PublishState.Fail });
+                                    if (!dev.Description.Any(l => l.Language.CultureCode == lang.CultureCode || string.IsNullOrEmpty(l.Text)))
+                                        actions.Add(new PublishAction() { Text = $"Geräte: Beschreibung enthält nicht alle Sprachen der Applikation.", State = PublishState.Fail });
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Loading MDT_KP_Binaereingang_V20a.knxprod into the ProdViewer results in a error in file CheckHelper, because this knxprod has several equal application versions.

Additional tere is no memory space calculated for Parameters and Unions with SavePath=Nowhere