### PR TITLE
Default procedure error with no load procedures

### DIFF
--- a/Kaenx.Creator/Classes/CheckHelper.cs
+++ b/Kaenx.Creator/Classes/CheckHelper.cs
@@ -310,25 +310,28 @@ namespace Kaenx.Creator.Classes {
                 //TODO check for Argument exist
             }
 
-            XElement temp = XElement.Parse(vers.Procedure);
-            temp.Attributes().Where((x) => x.IsNamespaceDeclaration).Remove();
-            foreach(XElement xele in temp.Descendants())
+            if (app.Mask.Procedure != ProcedureTypes.Default)
             {
-                if(xele.Name.LocalName == "OnError")
+                XElement temp = XElement.Parse(vers.Procedure);
+                temp.Attributes().Where((x) => x.IsNamespaceDeclaration).Remove();
+                foreach (XElement xele in temp.Descendants())
                 {
-                    if(!vers.IsMessagesActive)
+                    if (xele.Name.LocalName == "OnError")
                     {
-                        actions.Add(new PublishAction() { Text = $"Ladeprozedur: Es werden Meldungen verwendet, obwohl diese in der Applikation nicht aktiviert sind.", State = PublishState.Fail });
-                        return;
-                    }
+                        if (!vers.IsMessagesActive)
+                        {
+                            actions.Add(new PublishAction() { Text = $"Ladeprozedur: Es werden Meldungen verwendet, obwohl diese in der Applikation nicht aktiviert sind.", State = PublishState.Fail });
+                            return;
+                        }
 
-                    int id = -1;
-                    if(!int.TryParse(xele.Attribute("MessageRef").Value, out id))
-                        actions.Add(new PublishAction() { Text = $"Ladeprozedur: MessageRef ist kein Integer.", State = PublishState.Fail });
-                    if(id != -1)
-                    {
-                        if(!vers.Messages.Any(m => m.UId == id))
-                            actions.Add(new PublishAction() { Text = $"Ladeprozedur: MessageRef zeigt auf nicht vorhandene Meldung ({id}).", State = PublishState.Fail });
+                        int id = -1;
+                        if (!int.TryParse(xele.Attribute("MessageRef").Value, out id))
+                            actions.Add(new PublishAction() { Text = $"Ladeprozedur: MessageRef ist kein Integer.", State = PublishState.Fail });
+                        if (id != -1)
+                        {
+                            if (!vers.Messages.Any(m => m.UId == id))
+                                actions.Add(new PublishAction() { Text = $"Ladeprozedur: MessageRef zeigt auf nicht vorhandene Meldung ({id}).", State = PublishState.Fail });
+                        }
                     }
                 }
             }

--- a/Kaenx.Creator/Classes/ExportHelper.cs
+++ b/Kaenx.Creator/Classes/ExportHelper.cs
@@ -1,4 +1,4 @@
-﻿using Kaenx.Creator.Models;
+using Kaenx.Creator.Models;
 using Kaenx.Creator.Models.Dynamic;
 using Kaenx.Creator.Signing;
 using System;
@@ -326,33 +326,36 @@ namespace Kaenx.Creator.Classes
                 }
                 temp.SetAttributeValue("MaxEntries", ver.AssociationTableMaxCount);
                 xunderapp.Add(temp);
-                
-                temp = XElement.Parse(ver.Procedure);
-                //Write correct Memory Size if AutoLoad is activated
-                foreach(XElement xele in temp.Descendants())
-                {
-                    switch(xele.Name.LocalName)
-                    {
-                        case "LdCtrlWriteRelMem":
-                        {
-                            if(xele.Attribute("ObjIdx").Value == "4" && ver.Memories[0].IsAutoLoad)
-                            {
-                                xele.SetAttributeValue("Size", ver.Memories[0].Size);
-                            }
-                            break;
-                        }
 
-                        case "LdCtrlRelSegment":
+                if (app.Mask.Procedure != ProcedureTypes.Default)
+                {
+                    temp = XElement.Parse(ver.Procedure);
+                    //Write correct Memory Size if AutoLoad is activated
+                    foreach (XElement xele in temp.Descendants())
+                    {
+                        switch (xele.Name.LocalName)
                         {
-                            if(xele.Attribute("LsmIdx").Value == "4" && ver.Memories[0].IsAutoLoad)
-                            {
-                                xele.SetAttributeValue("Size", ver.Memories[0].Size);
-                            }
-                            break;
+                            case "LdCtrlWriteRelMem":
+                                {
+                                    if (xele.Attribute("ObjIdx").Value == "4" && ver.Memories[0].IsAutoLoad)
+                                    {
+                                        xele.SetAttributeValue("Size", ver.Memories[0].Size);
+                                    }
+                                    break;
+                                }
+
+                            case "LdCtrlRelSegment":
+                                {
+                                    if (xele.Attribute("LsmIdx").Value == "4" && ver.Memories[0].IsAutoLoad)
+                                    {
+                                        xele.SetAttributeValue("Size", ver.Memories[0].Size);
+                                    }
+                                    break;
+                                }
                         }
                     }
+                    ver.Procedure = temp.ToString();
                 }
-                ver.Procedure = temp.ToString();
                 temp.Attributes().Where((x) => x.IsNamespaceDeclaration).Remove();
                 temp.Name = XName.Get(temp.Name.LocalName, currentNamespace);
                 foreach(XElement xele in temp.Descendants())


### PR DESCRIPTION
When there is an imported knxprod with LoadProcedureStyle="DefaultProcedure" there is no <LoadProcedures> section in the xml file.
In this case there are errors in check and export.

For example there is the knxprod for the Jung 2138.10REG with this behavior.