### PR TITLE
Heatmap Calculation error with equal appVersion name

### DIFF
--- a/Kaenx.Creator/Classes/ImportHelper.cs
+++ b/Kaenx.Creator/Classes/ImportHelper.cs
@@ -286,7 +286,7 @@ namespace Kaenx.Creator.Classes
             currentVers = new AppVersion()
             {
                 Number = versNumber,
-                Name = "Imported",
+                Name = xapp.Attribute("Name").Value + "_Imported",
                 IsParameterRefAuto = false,
                 IsComObjectRefAuto = false,
                 IsMemSizeAuto = false,


### PR DESCRIPTION
If the program starts with a emtpy project and then import a knxprod (e.g. MDT_KP_BE_01_Universal_Interface_V16a.knxprod) there are many application programs with equal AppVersion Names (all are "Imported") In this case , the heatmap can't be calculated (errors are shown) Therefore the Names of the AppVersions have to be differently. So, my suggestion is to set the AppVerion name to the name of the application program with "_Imported" as attachment.