### PR TITLE
Fixed Clearing ParameterRef when Accessing Dynamic Choose Blocks

### DIFF
--- a/Kaenx.Creator/Models/Dynamic/DynChooseBlock.cs
+++ b/Kaenx.Creator/Models/Dynamic/DynChooseBlock.cs
@@ -31,7 +31,7 @@ namespace Kaenx.Creator.Models.Dynamic
         public bool IsLocal
         {
             get { return _isLocal; }
-            set { _isLocal = value; Changed("IsLocal"); _parameterRefObject = null; }
+            set { _isLocal = value; Changed("IsLocal"); }
         }
 
         private ParameterRef _parameterRefObject;


### PR DESCRIPTION
Hello Mike,

fixes the issue described [here](https://knx-user-forum.de/forum/projektforen/openknx/1778683-kaenx-creator-erstelle-knx-produktdatenbanken-mit-gui?p=1898568#post1898568) for me.

As mentioned in the forum please cross-check for possible side effects.

Best regards
Andreas