### PR TITLE
Add more information to app import selection

### DIFF
--- a/Kaenx.Creator/Controls/ListDialog.xaml
+++ b/Kaenx.Creator/Controls/ListDialog.xaml
@@ -5,7 +5,7 @@
         Title="Eingabe" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterScreen"
         Width="250"
         Icon="/FileLogo.ico">
-    <Grid Margin="15" FocusManager.FocusedElement="{Binding ElementName=AnswerBox}">
+    <Grid Margin="15">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />

--- a/Kaenx.Creator/Controls/MemorySectionsView.xaml
+++ b/Kaenx.Creator/Controls/MemorySectionsView.xaml
@@ -15,17 +15,19 @@
     x:Name="ViewControl">
 
     <UserControl.Resources>
+        <conv:IntToColorBrush x:Key="intToColBrush" />
+
         <DataTemplate x:Key="MemNormal">
             <StackPanel>
                 <StackPanel Orientation="Horizontal">
-                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[0]}" Margin="2" />
-                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[1]}" Margin="2" />
-                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[2]}" Margin="2" />
-                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[3]}" Margin="2" />
-                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[4]}" Margin="2" />
-                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[5]}" Margin="2" />
-                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[6]}" Margin="2" />
-                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[7]}" Margin="2" />
+                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[0], Converter={StaticResource intToColBrush}}" Margin="2" />
+                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[1], Converter={StaticResource intToColBrush}}" Margin="2" />
+                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[2], Converter={StaticResource intToColBrush}}" Margin="2" />
+                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[3], Converter={StaticResource intToColBrush}}" Margin="2" />
+                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[4], Converter={StaticResource intToColBrush}}" Margin="2" />
+                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[5], Converter={StaticResource intToColBrush}}" Margin="2" />
+                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[6], Converter={StaticResource intToColBrush}}" Margin="2" />
+                    <Rectangle Height="18" Width="18" Fill="{Binding FillColor[7], Converter={StaticResource intToColBrush}}" Margin="2" />
                 </StackPanel>
 
                 <HeaderedContentControl Header="{x:Static p:Resources.mem_para}">
@@ -116,112 +118,112 @@
                 <DataGridTemplateColumn Header="0" CellTemplate="{StaticResource CellTemplate}">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[0]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[0], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="1">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[1]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[1], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="2">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[2]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[2], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="3">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[3]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[3], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="4">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[4]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[4], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="5">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[5]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[5], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="6">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[6]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[6], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="7">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[7]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[7], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="8">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[8]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[8], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="9">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[9]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[9], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="A">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[10]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[10], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="B">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[11]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[11], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="C">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[12]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[12], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="D">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[13]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[13], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="E">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[14]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[14], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="F">
                     <DataGridTemplateColumn.CellStyle>
                         <Style TargetType="{x:Type DataGridCell}">
-                            <Setter Property="Background" Value="{Binding FillColor[15]}" />
+                            <Setter Property="Background" Value="{Binding FillColor[15], Converter={StaticResource intToColBrush}}" />
                         </Style>
                     </DataGridTemplateColumn.CellStyle>
                 </DataGridTemplateColumn>

--- a/Kaenx.Creator/Converter/IntToColorBrush.cs
+++ b/Kaenx.Creator/Converter/IntToColorBrush.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace Kaenx.Creator.Converter
+{
+    public class IntToColorBrush : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            switch (value){
+                case 0:
+                    return new SolidColorBrush(Colors.Gray);
+                case 1:
+                    return new SolidColorBrush(Colors.Violet);
+                case 2: 
+                    return new SolidColorBrush(Colors.Brown);
+                case 3:
+                    return new SolidColorBrush(Colors.Chocolate);
+                case 4:
+                    return new SolidColorBrush(Colors.Pink);
+                case 5:
+                    return new SolidColorBrush(Colors.Purple);
+                case 6:
+                    return new SolidColorBrush(Colors.Red);
+                case 7:
+                    return new SolidColorBrush(Colors.Green);
+                case 8:
+                    return new SolidColorBrush(Colors.Orange);
+                case 9:
+                    return new SolidColorBrush(Colors.Blue);
+                case 10:
+                    return new SolidColorBrush(Colors.MediumPurple);
+            }
+            return new SolidColorBrush(Colors.White);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
The import selection for knxprod with multiple applications had only shown the ID of the application program. It is very difficult to see whiche application is behind it. With this thange, also the name of the application program is shown in the selection window.

For example the MDT_KP_BE_01_Binary_Input_V20a.knxprod
![image](https://github.com/OpenKNX/Kaenx-Creator/assets/12214453/7843a7aa-0e7a-4c64-a040-ed912a562fdc)
