### PR TITLE
Fix additional address counter import

### DIFF
--- a/Kaenx.Creator/Classes/ImportHelper.cs
+++ b/Kaenx.Creator/Classes/ImportHelper.cs
@@ -426,7 +426,7 @@ namespace Kaenx.Creator.Classes
                 }
             }
 
-            if(xapp.Attribute("AdditionalAddressesCount") != null)
+            if(xapp.Attribute("AdditionalAddressesCount") != null && int.Parse(xapp.Attribute("AdditionalAddressesCount").Value) != 0)
             {
                 currentVers.IsBusInterfaceActive = true;
                 IEnumerable<XElement> interfaces = xstatic.Element(Get("BusInterfaces")).Elements();


### PR DESCRIPTION
For example with "MDT_KP_Jalousieaktor_V28.knxprod" there was a import error, because there is the entry 'AdditionalAddressesCount="0" ' in the application program. This causes an error, because the Creator wants to import BusInterfaces.