### PR TITLE
[bugfix] link for subitem not working for knxprod without modules

### DIFF
--- a/Kaenx.Creator/MainWindow.xaml.cs
+++ b/Kaenx.Creator/MainWindow.xaml.cs
@@ -105,7 +105,7 @@ namespace Kaenx.Creator
 
         public void GoToItem(object item, object module)
         {
-            if(module != null)
+            if(module != null && General.Application.IsModulesActive)
             {
                 VersionTabs.SelectedIndex = 7;
                 int index2 = item switch {


### PR DESCRIPTION
For knxprod without modules the link in e.g. ParameterRef pointing to the Parameter is not working. (null pointer exception)