### PR TITLE
[addon] show application Version as ETS

### DIFF
--- a/Kaenx.Creator/Converter/IntToVersion.cs
+++ b/Kaenx.Creator/Converter/IntToVersion.cs
@@ -10,33 +10,44 @@ namespace Kaenx.Creator.Converter
     public class IntToVersion : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            string hexString = ((int)value).ToString("X");
-            if(hexString.All(char.IsDigit)){
-                if(hexString.Length > 1)
-                    hexString = hexString.Insert(hexString.Length - 1, ".");
-            }else{
-                hexString = "";
-            }
-            return hexString;
+        {         
+            decimal majorVersion = Math.Floor((decimal)((int)value/16));
+            int minorVersion = (int)value % 16;
+            return $"{majorVersion}.{minorVersion}";
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            string hexString="";
+            int majorVersion;
+            int minorVersion;
+
             if(value.ToString().Contains('.'))
             {
                 string[] versions = value.ToString().Split('.');
-                hexString = versions[0] + versions[1];
+                
+                if(!int.TryParse(versions[0], out majorVersion))
+                    majorVersion = 0;
+
+                if(!int.TryParse(versions[1], out minorVersion))
+                    minorVersion = 0;   
+                    
+                if(minorVersion > 15)
+                {
+                    minorVersion /= 10;
+                    if(minorVersion > 15)
+                        minorVersion = 15;
+                }             
             }else
             {
-                hexString = value.ToString();
+                if(!int.TryParse(value.ToString(), out majorVersion))
+                    majorVersion = 0;
+
+                minorVersion = 0;
             }
 
-            int number;
-            if(!int.TryParse(hexString, NumberStyles.HexNumber, null, out number))
-                return 0;
-            return number;
+            majorVersion *= 16;
+
+            return majorVersion + minorVersion;
         }
     }
 }

--- a/Kaenx.Creator/Converter/IntToVersion.cs
+++ b/Kaenx.Creator/Converter/IntToVersion.cs
@@ -8,7 +8,6 @@ namespace Kaenx.Creator.Converter
 {
     public class IntToVersion : IValueConverter
     {
-
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             string hexString = ((int)value).ToString("X");
@@ -20,7 +19,7 @@ namespace Kaenx.Creator.Converter
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             string hexString="";
-            if(value.ToString().Contains("."))
+            if(value.ToString().Contains('.'))
             {
                 string[] versions = value.ToString().Split('.');
                 hexString = versions[0] + versions[1];

--- a/Kaenx.Creator/Converter/IntToVersion.cs
+++ b/Kaenx.Creator/Converter/IntToVersion.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Windows.Data;
+
+namespace Kaenx.Creator.Converter
+{
+    public class IntToVersion : IValueConverter
+    {
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string hexString = ((int)value).ToString("X");
+            if(hexString.Length > 1)
+                hexString = hexString.Insert(hexString.Length - 1, ".");
+            return hexString;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string hexString="";
+            if(value.ToString().Contains("."))
+            {
+                string[] versions = value.ToString().Split('.');
+                hexString = versions[0] + versions[1];
+            }else
+            {
+                hexString = value.ToString();
+            }
+
+            int number;
+            if(!int.TryParse(hexString, NumberStyles.HexNumber, null, out number))
+                return 0;
+            return number;
+        }
+    }
+}

--- a/Kaenx.Creator/Converter/IntToVersion.cs
+++ b/Kaenx.Creator/Converter/IntToVersion.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Windows.Data;
+using System.Linq;
 
 namespace Kaenx.Creator.Converter
 {
@@ -11,8 +12,12 @@ namespace Kaenx.Creator.Converter
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             string hexString = ((int)value).ToString("X");
-            if(hexString.Length > 1)
-                hexString = hexString.Insert(hexString.Length - 1, ".");
+            if(hexString.All(char.IsDigit)){
+                if(hexString.Length > 1)
+                    hexString = hexString.Insert(hexString.Length - 1, ".");
+            }else{
+                hexString = "";
+            }
             return hexString;
         }
 

--- a/Kaenx.Creator/MainWindow.xaml
+++ b/Kaenx.Creator/MainWindow.xaml
@@ -17,6 +17,7 @@
         Title="Kaenx-Creator" Height="720" Width="1300">
     <Window.Resources>
         <conv:IntToHex x:Key="IntToHex" />
+        <conv:IntToVersion x:Key="IntToVersion" />
         <conv:BoolNegation x:Key="BoolNegate" />
         <conv:EmptyOListToBool x:Key="EmptyListToBool" />
         <conv:EmptyToBool x:Key="EmptyToBool" />
@@ -649,7 +650,7 @@
 
                                 <StackPanel Grid.Column="1">
                                     <HeaderedContentControl Header="{x:Static p:Resources.prop_vers}">
-                                        <TextBox Text="{Binding Number, UpdateSourceTrigger=PropertyChanged}" />
+                                        <TextBox Text="{Binding Number, Converter={StaticResource IntToVersion}, UpdateSourceTrigger=PropertyChanged}" />
                                     </HeaderedContentControl>
                                     <HeaderedContentControl Header="{x:Static p:Resources.prop_versreplace}">
                                         <TextBox Text="{Binding ReplacesVersions, UpdateSourceTrigger=PropertyChanged}" />
@@ -875,7 +876,7 @@
                         </StackPanel.Resources>
                         
                         <HeaderedContentControl Header="{x:Static p:Resources.prop_vers}">
-                            <TextBox Text="{Binding General.Application.Number, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox Text="{Binding General.Application.Number, Converter={StaticResource IntToVersion}, UpdateSourceTrigger=PropertyChanged}" />
                         </HeaderedContentControl>
                         <HeaderedContentControl Header="{x:Static p:Resources.tpub_filename}">
                             <TextBox Text="{Binding General.FileName}" />

--- a/Kaenx.Creator/MainWindow.xaml
+++ b/Kaenx.Creator/MainWindow.xaml
@@ -650,6 +650,9 @@
 
                                 <StackPanel Grid.Column="1">
                                     <HeaderedContentControl Header="{x:Static p:Resources.prop_vers}">
+                                        <TextBox Text="{Binding Number, UpdateSourceTrigger=PropertyChanged}" />
+                                    </HeaderedContentControl>
+                                    <HeaderedContentControl Header="{x:Static p:Resources.prop_etsvers}">
                                         <TextBox Text="{Binding Number, Converter={StaticResource IntToVersion}, UpdateSourceTrigger=PropertyChanged}" />
                                     </HeaderedContentControl>
                                     <HeaderedContentControl Header="{x:Static p:Resources.prop_versreplace}">
@@ -876,7 +879,7 @@
                         </StackPanel.Resources>
                         
                         <HeaderedContentControl Header="{x:Static p:Resources.prop_vers}">
-                            <TextBox Text="{Binding General.Application.Number, Converter={StaticResource IntToVersion}, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBox Text="{Binding General.Application.Number, UpdateSourceTrigger=PropertyChanged}" />
                         </HeaderedContentControl>
                         <HeaderedContentControl Header="{x:Static p:Resources.tpub_filename}">
                             <TextBox Text="{Binding General.FileName}" />

--- a/Kaenx.Creator/MainWindow.xaml.cs
+++ b/Kaenx.Creator/MainWindow.xaml.cs
@@ -105,11 +105,7 @@ namespace Kaenx.Creator
 
         public void GoToItem(object item, object module)
         {
-<<<<<<< Updated upstream
             if(module != null)
-=======
-            if(module != null && module.GetType() == typeof(Kaenx.Creator.Models.Module))
->>>>>>> Stashed changes
             {
                 VersionTabs.SelectedIndex = 7;
                 int index2 = item switch {

--- a/Kaenx.Creator/MainWindow.xaml.cs
+++ b/Kaenx.Creator/MainWindow.xaml.cs
@@ -105,7 +105,11 @@ namespace Kaenx.Creator
 
         public void GoToItem(object item, object module)
         {
+<<<<<<< Updated upstream
             if(module != null)
+=======
+            if(module != null && module.GetType() == typeof(Kaenx.Creator.Models.Module))
+>>>>>>> Stashed changes
             {
                 VersionTabs.SelectedIndex = 7;
                 int index2 = item switch {

--- a/Kaenx.Creator/Properties/Resources.Designer.cs
+++ b/Kaenx.Creator/Properties/Resources.Designer.cs
@@ -410,6 +410,15 @@ namespace Kaenx.Creator.Properties {
                 return ResourceManager.GetString("prop_vers", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Veröffentlichen ähnelt.
+        /// </summary>
+        public static string prop_etsvers {
+            get {
+                return ResourceManager.GetString("prop_etsvers", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Veröffentlichen ähnelt.

--- a/Kaenx.Creator/Properties/Resources.de.resx
+++ b/Kaenx.Creator/Properties/Resources.de.resx
@@ -273,6 +273,10 @@
     <value>Version</value>
     <comment/>
   </data>
+  <data name="prop_etsvers" xml:space="preserve">
+    <value>ETS Version</value>
+    <comment/>
+  </data>
   <data name="prop_buscurrent" xml:space="preserve">
     <value>Busstrom</value>
     <comment/>

--- a/Kaenx.Creator/Properties/Resources.resx
+++ b/Kaenx.Creator/Properties/Resources.resx
@@ -273,6 +273,10 @@
     <value>Version</value>
     <comment/>
   </data>
+  <data name="prop_etsvers" xml:space="preserve">
+    <value>ETS Version</value>
+    <comment/>
+  </data>
   <data name="prop_buscurrent" xml:space="preserve">
     <value>Bus Current</value>
     <comment/>


### PR DESCRIPTION
The ETS shows the version of the application as hex number with a minor version after a point. This behavior is recreated with this change.

Now it looks like:

![app_version](https://github.com/user-attachments/assets/ad725aea-f7a6-4761-bbac-fa2b052a52e3)
