### PR TITLE
[bugfix] shows the expanded dynamic tree after link

### DIFF
--- a/Kaenx.Creator/Controls/DynamicView.xaml
+++ b/Kaenx.Creator/Controls/DynamicView.xaml
@@ -609,6 +609,7 @@
             <TreeView.ItemContainerStyle>
 				<Style TargetType="TreeViewItem">
 					<Setter Property="IsExpanded" Value="{Binding IsExpanded}" />
+					<Setter Property="IsSelected" Value="{Binding IsSelected}" />
 				</Style>
 			</TreeView.ItemContainerStyle>
             <TreeView.Resources>

--- a/Kaenx.Creator/Controls/DynamicView.xaml.cs
+++ b/Kaenx.Creator/Controls/DynamicView.xaml.cs
@@ -51,7 +51,9 @@ namespace Kaenx.Creator.Controls
             {
                 ditem = ditem.Parent;
                 ditem.IsExpanded = true;
-            }
+            }    
+            DynamicList.Items.Refresh();
+            DynamicList.UpdateLayout();
         }
 
         private void SetExpandedFalse(Models.Dynamic.IDynItems item)

--- a/Kaenx.Creator/Controls/DynamicView.xaml.cs
+++ b/Kaenx.Creator/Controls/DynamicView.xaml.cs
@@ -51,9 +51,10 @@ namespace Kaenx.Creator.Controls
             {
                 ditem = ditem.Parent;
                 ditem.IsExpanded = true;
-            }    
+            }
             DynamicList.Items.Refresh();
             DynamicList.UpdateLayout();
+            ((Models.Dynamic.IDynItems)item).IsSelected = true;
         }
 
         private void SetExpandedFalse(Models.Dynamic.IDynItems item)


### PR DESCRIPTION
After click on a link from check helper to dynamic section, the tree was not shown as expanded at the correct way.