### PR TITLE
[addon] check for set display order if PreETS4 is set

### DIFF
--- a/Kaenx.Creator/Classes/CheckHelper.cs
+++ b/Kaenx.Creator/Classes/CheckHelper.cs
@@ -507,6 +507,9 @@ namespace Kaenx.Creator.Classes {
             }
         
             foreach(ParameterRef para in vbase.ParameterRefs) {
+                if(ver.IsPreETS4 && para.DisplayOrder == -1)
+                    actions.Add(new PublishAction() { Text = "\t" + string.Format(Properties.Messages.check_ver_pararef_no_display_order, para.Name, para.UId), State = PublishState.Fail, Item = para, Module = mod });
+                
                 if(para.ParameterObject == null) actions.Add(new PublishAction() { Text = "\t" + string.Format(Properties.Messages.check_ver_pararef_no_para, para.Name, para.UId), State = PublishState.Fail, Item = para, Module = mod });
                 else {
                     if(para.ParameterObject.ParameterTypeObject == null || string.IsNullOrEmpty(para.Value))

--- a/Kaenx.Creator/Properties/Messages.Designer.cs
+++ b/Kaenx.Creator/Properties/Messages.Designer.cs
@@ -1099,6 +1099,12 @@ namespace Kaenx.Creator.Properties {
                 return ResourceManager.GetString("check_ver_pararef_no_para", resourceCulture);
             }
         }
+
+        public static string check_ver_pararef_no_display_order {
+            get {
+                return ResourceManager.GetString("check_ver_pararef_no_display_order", resourceCulture);
+            }
+        }
         
         public static string check_ver_com_not_unique {
             get {

--- a/Kaenx.Creator/Properties/Messages.de.resx
+++ b/Kaenx.Creator/Properties/Messages.de.resx
@@ -809,6 +809,10 @@
     <value>ParameterRef {0} ({1}): Kein Parameter ausgewählt</value>
     <comment>Name; UId</comment>
   </data>
+  <data name="check_ver_pararef_no_display_order" xml:space="preserve">
+    <value>ParameterRef {0} ({1}): Bei PreETS4 muss die DisplayOrder gesetzt werden</value>
+    <comment>Name; UId</comment>
+  </data>
   <data name="check_ver_com_not_unique" xml:space="preserve">
     <value>ComObjectNumers sind nicht eindeutig. Die IDs werden aufsteigend neu vergeben</value>
     <comment>Name; UId</comment>

--- a/Kaenx.Creator/Properties/Messages.resx
+++ b/Kaenx.Creator/Properties/Messages.resx
@@ -809,6 +809,10 @@
     <value>ParameterRef {0} ({1}): No parameter selected</value>
     <comment>Name; UId</comment>
   </data>
+  <data name="check_ver_pararef_no_display_order" xml:space="preserve">
+    <value>ParameterRef {0} ({1}): At PreETS4 the DisplayOrder has to be set</value>
+    <comment>Name; UId</comment>
+  </data>
   <data name="check_ver_com_not_unique" xml:space="preserve">
     <value>ComObjectNumbers are not unique. IDs will be counted up</value>
     <comment>Name; UId</comment>


### PR DESCRIPTION
If the "Is PreETS4" option is activated, the ParameterRefs have to be sorted with the DisplayOrder Parameter.
Otherwise the Parameters in ETS are through each other.