### PR TITLE
Add calculation of ComObject memory table

### DIFF
--- a/Kaenx.Creator/Controls/MemorySectionsView.xaml
+++ b/Kaenx.Creator/Controls/MemorySectionsView.xaml
@@ -86,13 +86,16 @@
         <DataTemplate x:Key="MemASTable">
             <TextBlock TextWrapping="Wrap" Text="{x:Static p:Resources.mem_ast}" />
         </DataTemplate>
-
+        <DataTemplate x:Key="MemBcu1Data">
+            <TextBlock TextWrapping="Wrap" Text="{x:Static p:Resources.mem_bcu1}" />
+        </DataTemplate>
         <select:MemorySelector x:Key="MemorySelector"
                 Normal="{StaticResource MemNormal}"
                 Module="{StaticResource MemModule}"
                 GATable="{StaticResource MemGATable}"
                 COTable="{StaticResource MemCOTable}"
                 ASTable="{StaticResource MemASTable}"
+                Bcu1Data="{StaticResource MemBcu1Data}"
                  />
     </UserControl.Resources>
     

--- a/Kaenx.Creator/MainWindow.xaml.cs
+++ b/Kaenx.Creator/MainWindow.xaml.cs
@@ -857,7 +857,7 @@ namespace Kaenx.Creator
         private void ClickCalcHeatmap(object sender, RoutedEventArgs e)
         {
             Models.Memory mem = (sender as Button).DataContext as Models.Memory;
-            Kaenx.Creator.Classes.MemoryHelper.MemoryCalculation(General.Application, mem);     
+            Kaenx.Creator.Classes.MemoryHelper.MemoryCalculation(General, mem);     
         }
 
         private void ClickCheckHyperlink(object sender, RoutedEventArgs e)

--- a/Kaenx.Creator/Properties/Resources.Designer.cs
+++ b/Kaenx.Creator/Properties/Resources.Designer.cs
@@ -2438,6 +2438,12 @@ namespace Kaenx.Creator.Properties {
                 return ResourceManager.GetString("mem_ast", resourceCulture);
             }
         }
+
+        public static string mem_bcu1 {
+            get {
+                return ResourceManager.GetString("mem_bcu1", resourceCulture);
+            }
+        }
         
         public static string tmod_prefix {
             get {

--- a/Kaenx.Creator/Properties/Resources.de.resx
+++ b/Kaenx.Creator/Properties/Resources.de.resx
@@ -1321,6 +1321,10 @@
     <value>Hier wird die Assoziationstabelle gespeichert.</value>
     <comment/>
   </data>
+  <data name="mem_bcu1" xml:space="preserve">
+    <value>Hier werden die Ladeprozedur Daten der BCU1 gespeichert.</value>
+    <comment/>
+  </data>
   <data name="tmod_prefix" xml:space="preserve">
     <value>Prefix</value>
     <comment/>

--- a/Kaenx.Creator/Properties/Resources.resx
+++ b/Kaenx.Creator/Properties/Resources.resx
@@ -1321,6 +1321,10 @@
     <value>The AssoziationTable will be placed here.</value>
     <comment/>
   </data>
+  <data name="mem_bcu1" xml:space="preserve">
+    <value>The BCU1 load prodecure data will be placed here.</value>
+    <comment/>
+  </data>
   <data name="tmod_prefix" xml:space="preserve">
     <value>Prefix</value>
     <comment/>

--- a/Kaenx.Creator/Selectors/MemorySelector.cs
+++ b/Kaenx.Creator/Selectors/MemorySelector.cs
@@ -14,6 +14,7 @@ namespace Kaenx.Creator.Selectors
         public DataTemplate COTable { get; set; }
         public DataTemplate ASTable { get; set; }
         public DataTemplate Module { get; set; }
+        public DataTemplate Bcu1Data { get; set; }
 
 
         public override DataTemplate SelectTemplate(object item, DependencyObject container)
@@ -34,6 +35,9 @@ namespace Kaenx.Creator.Selectors
 
                 case MemoryByteUsage.Module:
                     return Module;
+
+                case MemoryByteUsage.Bcu1Data:
+                    return Bcu1Data;
             }
 
             return Normal;


### PR DESCRIPTION
This is an addition of the correct calculation of the ComObject Table size and display the BCU1 loadr procedure data bytes in the hetamap.

This PR belogs to https://github.com/OpenKNX/Kaenx-Creator-Share/pull/6 

To add it finally, PR https://github.com/OpenKNX/Kaenx-Creator-Share/pull/4 has to be merged, because the MaskVersion.ManagementModel has to be implemented.