### PR TITLE
[bugfix] link to choose from dynamic

### DIFF
--- a/Kaenx.Creator/Controls/DynamicView.xaml.cs
+++ b/Kaenx.Creator/Controls/DynamicView.xaml.cs
@@ -278,7 +278,7 @@ namespace Kaenx.Creator.Controls
 
         private void DynChooseParaRefLink(object sender, RoutedEventArgs e)
         {
-            Models.ParameterRef paraRef = ((sender as System.Windows.Documents.Hyperlink).DataContext as Models.Dynamic.DynChooseBlock).ParameterRefObject;
+            Models.ParameterRef paraRef = ((sender as System.Windows.Documents.Hyperlink).DataContext as Models.Dynamic.IDynChoose).ParameterRefObject;
             MainWindow.Instance.GoToItem(paraRef, Module);
         }
 


### PR DESCRIPTION
If there is a link on a channel choose the link fails. Now there is the type of the parent of both coose types.