### PR TITLE
check ComObjectRef Uids when removing a ComObjectRef

### DIFF
--- a/Kaenx.Creator/Controls/ComObjectRefView.xaml.cs
+++ b/Kaenx.Creator/Controls/ComObjectRefView.xaml.cs
@@ -84,7 +84,7 @@ namespace Kaenx.Creator.Controls
             ComObjectRef cref = ComobjectRefList.SelectedItem as Models.ComObjectRef;
 
             List<int> uids = new List<int>();
-            ClearHelper.GetIDs(Module.Dynamics[0], uids, true);
+            ClearHelper.GetIDs(Module.Dynamics[0], uids, false);
             if(uids.Contains(cref.UId) && MessageBoxResult.No == MessageBox.Show(Properties.Messages.comref_delete, Properties.Messages.comref_delete_title, MessageBoxButton.YesNo, MessageBoxImage.Warning))
                     return;
 


### PR DESCRIPTION
in current code, when removing a ComObjectRef, it collects the uids with 
```
ClearHelper.GetIDs(Module.Dynamics[0], uids, true);
```
which actually collects the parameter ref uids, should use
```
ClearHelper.GetIDs(Module.Dynamics[0], uids, false);
```
where the function is defined as
```
public static void GetIDs(IDynItems dyn, List<int> uids, bool isPara) {
}
```
this bug make wrong check of the com object uid in the collection of parameter ref uid